### PR TITLE
Fixed #503 

### DIFF
--- a/application/src/main/java/org/drugis/addis/presentation/wizard/MetaCriteriaAndAlternativesPresentation.java
+++ b/application/src/main/java/org/drugis/addis/presentation/wizard/MetaCriteriaAndAlternativesPresentation.java
@@ -61,10 +61,8 @@ import com.jgoodies.binding.value.AbstractValueModel;
 import com.jgoodies.binding.value.ValueModel;
 
 public class MetaCriteriaAndAlternativesPresentation extends CriteriaAndAlternativesPresentation<DrugSet> {
-	private final class AutoSelectMetaAnalysisListener implements
-			ListDataListener {
-		public void intervalRemoved(ListDataEvent e) {
-		}
+	private final class AutoSelectMetaAnalysisListener implements ListDataListener {
+		public void intervalRemoved(ListDataEvent e) { }
 
 		public void intervalAdded(ListDataEvent e) {
 			autoSelectInterval(e.getIndex0(), e.getIndex1());
@@ -218,12 +216,25 @@ public class MetaCriteriaAndAlternativesPresentation extends CriteriaAndAlternat
 
 		d_selectedMetaAnalysesPairs = new ContentAwareListModel<CriterionAnalysisPair>(new ArrayListModel<CriterionAnalysisPair>(), 
 				new String[] {CriterionAnalysisPair.PROPERTY_ANALYSIS});
-		FilteredObservableList<CriterionAnalysisPair> pairsWithIncludedCriterion = 
-			new FilteredObservableList<CriterionAnalysisPair>(d_selectedMetaAnalysesPairs, new Filter<CriterionAnalysisPair>() {
+		
+		// Filter the CriterionAnalysisPair list to include only selected criteria.
+		final Filter<CriterionAnalysisPair> criterionSelectedFilter = new Filter<CriterionAnalysisPair>() {
 			public boolean accept(CriterionAnalysisPair obj) {
 				return getSelectedCriteria().contains(obj.getCriterion());
 			}
+		};
+		final FilteredObservableList<CriterionAnalysisPair> pairsWithIncludedCriterion = 
+			new FilteredObservableList<CriterionAnalysisPair>(d_selectedMetaAnalysesPairs, criterionSelectedFilter);
+		// Re-calculate the filtered list when the selected criteria change.
+		getSelectedCriteria().addListDataListener(new ListDataListener() {
+			public void intervalRemoved(ListDataEvent e) { update(); }
+			public void intervalAdded(ListDataEvent e) { update(); }
+			public void contentsChanged(ListDataEvent e) { update(); }
+			private void update() {
+				pairsWithIncludedCriterion.setFilter(criterionSelectedFilter);
+			}
 		});
+		
 		d_selectedMetaAnalyses = new TransformedObservableList<CriterionAnalysisPair, MetaAnalysis>(pairsWithIncludedCriterion, 
 				new Transform<CriterionAnalysisPair, MetaAnalysis>() {
 					public MetaAnalysis transform(CriterionAnalysisPair pair) {
@@ -238,6 +249,7 @@ public class MetaCriteriaAndAlternativesPresentation extends CriteriaAndAlternat
 		
 		getSelectedCriteria().addListDataListener(new AutoSelectMetaAnalysisListener());
 	}
+
 
 	public ObservableList<MetaAnalysis> getSelectedMetaAnalyses() {
 		return d_selectedMetaAnalyses;

--- a/application/src/test/java/org/drugis/addis/presentation/wizard/BenefitRiskWizardPMTest.java
+++ b/application/src/test/java/org/drugis/addis/presentation/wizard/BenefitRiskWizardPMTest.java
@@ -455,7 +455,7 @@ public class BenefitRiskWizardPMTest {
 	}
 	
 	@Test
-	public void testLyndOBrienAlternativesRestrictions(){
+	public void testLyndOBrienAlternativesRestrictions() {
 		MetaCriteriaAndAlternativesPresentation pm = d_pm.getMetaBRPresentation();
 		d_pm.getAnalysisTypeHolder().setValue(AnalysisType.LyndOBrien);
 		pm.getCriterionSelectedModel(ExampleData.buildEndpointHamd()).setValue(true);
@@ -473,7 +473,7 @@ public class BenefitRiskWizardPMTest {
 	}
 
 	@Test
-	public void testLyndOBrienOutcomesRestrictions(){
+	public void testLyndOBrienOutcomesRestrictions() {
 		MetaCriteriaAndAlternativesPresentation pm = d_pm.getMetaBRPresentation();
 		d_pm.getAnalysisTypeHolder().setValue(AnalysisType.LyndOBrien); 
 		pm.getCriterionSelectedModel(ExampleData.buildEndpointHamd()).setValue(true);
@@ -582,5 +582,26 @@ public class BenefitRiskWizardPMTest {
 		
 		d_pm.getDecisionContextFields().get(0).getModel().setValue("Test");
 		assertEquals("Test", d_pm.getDecisionContext().getTherapeuticContext());
+	}
+	
+	@Test
+	public void testDeselectedCriterionWithSelectedMetaAnalysisShouldBeExcluded() {
+		MetaCriteriaAndAlternativesPresentation pm = d_pm.getMetaBRPresentation();
+		d_pm.getAnalysisTypeHolder().setValue(AnalysisType.LyndOBrien);
+
+		// Set a meta-analysis for HAM-D, but deselect HAM-D afterwards
+		pm.getCriterionSelectedModel(ExampleData.buildEndpointHamd()).setValue(true);
+		pm.getMetaAnalysesSelectedModel(ExampleData.buildEndpointHamd()).setValue(ExampleData.buildNetworkMetaAnalysisHamD());
+		pm.getCriterionSelectedModel(ExampleData.buildEndpointHamd()).setValue(false);
+		
+		// Select two (other) criteria
+		pm.getCriterionSelectedModel(ExampleData.buildEndpointCgi()).setValue(true);
+		pm.getCriterionSelectedModel(ExampleData.buildAdverseEventConvulsion()).setValue(true);
+
+		// Select two alternatives
+		pm.getAlternativeSelectedModel(d_sertrSet).setValue(true);
+		pm.getAlternativeSelectedModel(d_fluoxSet).setValue(true);
+		
+		assertEquals(Arrays.asList(ExampleData.buildNetworkMetaAnalysisCgi(), null), pm.getSelectedMetaAnalyses());
 	}
 }


### PR DESCRIPTION
When selecting and then deselecting a Criterion in the BR-wizard the underlying Meta Analysis will still be used
